### PR TITLE
Added support for Longs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/*
 .project
 bin/
 /target
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <dependency>      
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.7.6</version>
+      <version>1.9.13</version>
     </dependency>    
     <dependency>      
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/aws/services/cloudsearchv2/documents/AmazonCloudSearchAddRequest.java
+++ b/src/main/java/aws/services/cloudsearchv2/documents/AmazonCloudSearchAddRequest.java
@@ -46,6 +46,10 @@ public class AmazonCloudSearchAddRequest {
 	public void addField(String name, Integer value) {
 		fields.put(name, value);
 	}	
+		
+	public void addField(String name, Long value) {
+		fields.put(name, value);
+	}	
 	
 	public void addField(String name, List<String> values) {
 		fields.put(name, values);


### PR DESCRIPTION
AWS supports submitting 64bit integers to cloud search. Overloading this method should do the trick.
